### PR TITLE
Allow direct access to the backend

### DIFF
--- a/src/main/java/ch/cern/marathonsso/JavaAuthorizer.java
+++ b/src/main/java/ch/cern/marathonsso/JavaAuthorizer.java
@@ -52,6 +52,11 @@ public class JavaAuthorizer implements Authorizer {
     }
     private boolean isAuthorized(JavaIdentity principal, Action action, PathId path) {
         try {
+          // Direct access to the backend is always allowed, because in
+          // any case one could spoof the headers.
+          if (principal.isDirect())
+            return true;
+
           List<String> egroups = Arrays.asList(principal.getEgroups())
                                  .stream()
                                  .filter(e -> e.startsWith(VALID_GROUP_PREFIX))

--- a/src/main/java/ch/cern/marathonsso/JavaIdentity.java
+++ b/src/main/java/ch/cern/marathonsso/JavaIdentity.java
@@ -7,10 +7,15 @@ class JavaIdentity implements Identity {
 
     private final String name;
     private final String[] egroups;
+    private final boolean isDirect;
 
     public JavaIdentity(String name, String[] egroups) {
         this.name = name;
         this.egroups = egroups;
+        if (name == null && egroups == null)
+          this.isDirect = true;
+        else
+          this.isDirect = false;
     }
 
     public String getName() {
@@ -19,5 +24,9 @@ class JavaIdentity implements Identity {
 
     public String[] getEgroups() {
         return egroups;
+    }
+
+    public boolean isDirect() {
+      return this.isDirect;
     }
 }


### PR DESCRIPTION
In case a client reaches the backend without passing through the
frontend it will not have the authentication headers being set. In this
particular case we allow any kind of action, given that in any case one
could spoof headers, so any protection would be useless. This means that
you must be absolutely sure that only the frontend can reach the backend
by limiting access to marathon backend via the firewall or by binding it
to localhost.